### PR TITLE
feat: make fonts.css optional via includeFont plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ If you desire to establish a custom primary color, you may incorporate the `prim
       }),
    ```
 
+If you want to avoid including the Inter font in your project, you can add the following parameter:
+
+```javascript
+require('@placetopay/spartan-vue/plugin')({
+   includeFont: false,
+}),
+```
+
 ## Usage
 ```html
 <script setup>

--- a/src/expose/plugin.js
+++ b/src/expose/plugin.js
@@ -24,8 +24,6 @@ export default plugin.withOptions(
                 return acc;
             }, {});
 
-            config.addBase({ "@import '@placetopay/spartan-vue/style.css'": true });
-
             if (options.includeFont !== false) {
                 config.addBase({ '@import': "url('https://rsms.me/inter/inter.css')" });
             }

--- a/src/expose/plugin.js
+++ b/src/expose/plugin.js
@@ -24,11 +24,15 @@ export default plugin.withOptions(
                 return acc;
             }, {});
 
+            config.addBase({ "@import '@placetopay/spartan-vue/style.css'": true });
+
+            if (options.includeFont !== false) {
+                config.addBase({ '@import': "url('https://rsms.me/inter/inter.css')" });
+            }
+
             config.addUtilities({
                 ':root': colorUtilities,
                 html: { '@apply antialiased': {} },
-                // "@import '@placetopay/spartan-vue/style.css';": true, NOT WORKS
-                // "@import url('https://rsms.me/inter/inter.css')": true, NOT WORKS
                 '.s-ring': {
                     '@apply duration-150 ring ring-spartan-primary-100 border-spartan-primary-300 z-10': {},
                 },


### PR DESCRIPTION
This PR enhances the Tailwind plugin in `spartan-vue` by making the global font import (`Inter` from rsms.me) optional via the new `includeFont` flag.

Summary:
- Introduces `includeFont` flag (defaults to `true`) to optionally include the Inter font from CDN.
- No longer requires manual import of base styles — they are now injected automatically via `addBase()`:
 
	
Usage:

```js
import defaultTheme from 'tailwindcss/defaultTheme';
import spartanPlugin from '@placetopay/spartan-vue/tailwind';

const includeFont = false; // 👈 turn off global font import

export default {
  theme: {
    extend: {
      fontFamily: {
        sans: includeFont  // 👈 
          ? ['Inter', ...defaultTheme.fontFamily.sans]
          : [...defaultTheme.fontFamily.sans],
      },
    },
  },
  plugins: [spartanPlugin({ includeFont : })],
};
```