### PR TITLE
Handle null links in pagination

### DIFF
--- a/src/components/spartan/SPaginator/SPaginator.stories.ts
+++ b/src/components/spartan/SPaginator/SPaginator.stories.ts
@@ -307,43 +307,21 @@ export const LaravelAndInertia = createVariation({
 <SPaginator :laravel="mockLaravelResponse" :inertiaRouter="router" :pageSizes="[10, 20, 30, 100]" />
 
 <!-- mockLaravelResponse: {
-    "data": [
+    total: 50,
+    per_page: 15,
+    current_page: 1,
+    last_page: 4,
+    first_page_url: 'http://laravel.app?page=1',
+    last_page_url: 'http://laravel.app?page=4',
+    next_page_url: 'http://laravel.app?page=2',
+    prev_page_url: null,
+    path: 'http://laravel.app',
+    from: 1,
+    to: 15,
+    data: [
         { id: 1, name: 'John Doe' },
         { id: 2, name: 'Jane Doe' },
         { id: 3, name: 'John Smith' },
     ],
-    "total": 4,
-    "links": {
-        "first": "http://laravel.app?page=1",
-        "last": "http://laravel.app?page=1",
-        "prev": null,
-        "next": null
-    },
-    "meta": {
-        "current_page": 1,
-        "from": 1,
-        "last_page": 1,
-        "links": [
-            {
-                "url": null,
-                "label": "&laquo; Previous",
-                "active": false
-            },
-            {
-                "url": "http://laravel.app?page=1",
-                "label": "1",
-                "active": true
-            },
-            {
-                "url": null,
-                "label": "Next &raquo;",
-                "active": false
-            }
-        ],
-        "path": "http://laravel.app",
-        "per_page": 20,
-        "to": 4,
-        "total": 4
-    }
 } -->`,
 });

--- a/src/components/spartan/SPaginator/SPaginator.stories.ts
+++ b/src/components/spartan/SPaginator/SPaginator.stories.ts
@@ -307,21 +307,43 @@ export const LaravelAndInertia = createVariation({
 <SPaginator :laravel="mockLaravelResponse" :inertiaRouter="router" :pageSizes="[10, 20, 30, 100]" />
 
 <!-- mockLaravelResponse: {
-    total: 50,
-    per_page: 15,
-    current_page: 1,
-    last_page: 4,
-    first_page_url: 'http://laravel.app?page=1',
-    last_page_url: 'http://laravel.app?page=4',
-    next_page_url: 'http://laravel.app?page=2',
-    prev_page_url: null,
-    path: 'http://laravel.app',
-    from: 1,
-    to: 15,
-    data: [
+    "data": [
         { id: 1, name: 'John Doe' },
         { id: 2, name: 'Jane Doe' },
         { id: 3, name: 'John Smith' },
     ],
+    "total": 4,
+    "links": {
+        "first": "http://laravel.app?page=1",
+        "last": "http://laravel.app?page=1",
+        "prev": null,
+        "next": null
+    },
+    "meta": {
+        "current_page": 1,
+        "from": 1,
+        "last_page": 1,
+        "links": [
+            {
+                "url": null,
+                "label": "&laquo; Previous",
+                "active": false
+            },
+            {
+                "url": "http://laravel.app?page=1",
+                "label": "1",
+                "active": true
+            },
+            {
+                "url": null,
+                "label": "Next &raquo;",
+                "active": false
+            }
+        ],
+        "path": "http://laravel.app",
+        "per_page": 20,
+        "to": 4,
+        "total": 4
+    }
 } -->`,
 });

--- a/src/components/spartan/SPaginator/SPaginator.vue
+++ b/src/components/spartan/SPaginator/SPaginator.vue
@@ -231,24 +231,27 @@ const updateSize = (value?: string | number) => {
 };
 
 const getLaravelAsLinksProps = (pageItem?: string | number) => {
-    if (!laravel?.asLinks)
+    if (!laravel?.asLinks) {
         return {
             onClick: pageItem === 'prev' ? prev : pageItem === 'next' ? next : () => selectPage(Number(pageItem)),
         };
+    }
 
     const data: any = {};
 
     data.as = laravel.asLinks;
 
     if (pageItem === 'prev') {
-        const href = vLaravel.value?.prevPage;
-        if (href != null) data.href = href;
+        data.href = vLaravel.value?.prevPage;
     } else if (pageItem === 'next') {
-        const href = vLaravel.value?.nextPage;
-        if (href != null) data.href = href;
+        data.href = vLaravel.value?.nextPage;
     } else {
         const link = vLaravel.value?.links?.find((link: any) => link.label === String(pageItem));
-        if (link?.url != null) data.href = link.url;
+        data.href = link?.url;
+    }
+
+    if (data.href == null) {
+        data.as = 'button';
     }
 
     return data;

--- a/src/components/spartan/SPaginator/SPaginator.vue
+++ b/src/components/spartan/SPaginator/SPaginator.vue
@@ -3,7 +3,7 @@ import type { TPaginatorProps, TPaginatorEmits, TLaravelResource } from './types
 import { translator } from '@/helpers';
 import { SSelect } from '@spartan';
 import { SButtonGroup, SButtonGroupItem } from '../SButtonGroup';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { twMerge } from 'tailwind-merge';
 
 const emit = defineEmits<TPaginatorEmits>();
@@ -241,12 +241,14 @@ const getLaravelAsLinksProps = (pageItem?: string | number) => {
     data.as = laravel.asLinks;
 
     if (pageItem === 'prev') {
-        data.href = vLaravel.value?.prevPage;
+        const href = vLaravel.value?.prevPage;
+        if (href != null) data.href = href;
     } else if (pageItem === 'next') {
-        data.href = vLaravel.value?.nextPage;
+        const href = vLaravel.value?.nextPage;
+        if (href != null) data.href = href;
     } else {
         const link = vLaravel.value?.links?.find((link: any) => link.label === String(pageItem));
-        data.href = link?.url;
+        if (link?.url != null) data.href = link.url;
     }
 
     return data;


### PR DESCRIPTION
Este PR forza a que el componente a renderizar sean botones cuando el valor es null, de esta forma, se previene que el componente Link de Inertia reciba un nulo en el prop href.