### PR TITLE
feat: add `validate` option to `SFilter` fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add `validate` option to `SFilter` fields.
+
 ## 2.5.0 - 2025-09-08
 ### Added
 - `STemplateHeaderTable` component.

--- a/src/components/spartan/SFilter/SFilter.stories.ts
+++ b/src/components/spartan/SFilter/SFilter.stories.ts
@@ -337,15 +337,9 @@ export const Validation = createVariation({
                         operators: ['equal'],
                     },
                 },
-                validate: (value: any, operator: TOperator): Promise<string | null> => {
-                    return new Promise((resolve) => {
-                        const binRegex = /^\d{6}$/;
-                        if (!binRegex.test(value)) {
-                            resolve('Invalid bin');
-                        } else {
-                            resolve(null);
-                        }
-                    });
+                validate: async (value: any, operator: TOperator): Promise<string | null> => {
+                    const binRegex = /^\d{6}$/;
+                    return !binRegex.test(value) ? 'Invalid bin' : null;
                 },
             },
             {

--- a/src/components/spartan/SFilter/SFilter.stories.ts
+++ b/src/components/spartan/SFilter/SFilter.stories.ts
@@ -3,7 +3,6 @@ import { StoryPanel } from '@internal';
 import { buildDesign, buildSourceBinding, createDefault, createVariation } from '@/helpers';
 import { ref } from 'vue';
 import type { TField, TOperator, TSaveData } from './types';
-import type { Ref } from 'vue';
 
 export default {
     component: SFilter,
@@ -338,13 +337,15 @@ export const Validation = createVariation({
                         operators: ['equal'],
                     },
                 },
-                validate: (value: any, operator: TOperator, error: Ref<string | null>): true | false => {
-                    const binRegex = /^(\d{6})/;
-                    if (!binRegex.test(value)) {
-                        error.value = 'Invalid bin';
-                        return false;
-                    }
-                    return true;
+                validate: (value: any, operator: TOperator): Promise<string | null> => {
+                    return new Promise((resolve) => {
+                        const binRegex = /^\d{6}$/;
+                        if (!binRegex.test(value)) {
+                            resolve('Invalid bin');
+                        } else {
+                            resolve(null);
+                        }
+                    });
                 },
             },
             {
@@ -370,24 +371,22 @@ export const Validation = createVariation({
                         operators: ['between', 'notBetween'],
                     },
                 },
-                validate: (value: any, operator: TOperator, error: Ref<string | null>): true | false => {
-                    let isValid = true;
+                validate: (value: any, operator: TOperator): string | null => {
+                    let error = null;
                     switch (operator) {
                         case 'between':
                         case 'notBetween':
                             if (parseFloat(value[0]) > parseFloat(value[1])) {
-                                error.value = 'Invalid amount range';
-                                isValid = false;
+                                error = 'Invalid amount range';
                             }
                             break;
                         default:
                             if (parseFloat(value) <= 0) {
-                                error.value = 'Invalid amount';
-                                isValid = false;
+                                error = 'Invalid amount';
                             }
                             break;
                     }
-                    return isValid;
+                    return error;
                 },
             },
             {
@@ -399,15 +398,11 @@ export const Validation = createVariation({
                         operators: ['between'],
                     },
                 },
-                validate: (value: any, operator: TOperator, error: Ref<string | null>): true | false => {
+                validate: (value: any, operator: TOperator): string | null => {
                     const from = new Date(value[0]);
                     const to = new Date(value[1]);
                     const diff = (to?.getTime() - from?.getTime()) / (1000 * 60 * 60 * 24);
-                    if (diff > 30) {
-                        error.value = 'The range must not greater 30 days';
-                        return false;
-                    }
-                    return true;
+                    return diff > 30 ? 'The range must not greater 30 days' : null;
                 },
             },
         ]);

--- a/src/components/spartan/SFilter/SFilter.test.ts
+++ b/src/components/spartan/SFilter/SFilter.test.ts
@@ -207,15 +207,9 @@ describe('SFilter', () => {
                                 operators: ['equal'],
                             },
                         },
-                        validate: (value: any, operator: TOperator): Promise<string | null> => {
-                            return new Promise((resolve) => {
-                                const binRegex = /^\d{6}$/;
-                                if (!binRegex.test(value)) {
-                                    resolve('Invalid bin');
-                                } else {
-                                    resolve(null);
-                                }
-                            });
+                        validate: async (value: any, operator: TOperator): Promise<string | null> => {
+                            const binRegex = /^\d{6}$/;
+                            return !binRegex.test(value) ? 'Invalid bin' : null;
                         },
                     },
                 ],

--- a/src/components/spartan/SFilter/SFilter.test.ts
+++ b/src/components/spartan/SFilter/SFilter.test.ts
@@ -207,13 +207,15 @@ describe('SFilter', () => {
                                 operators: ['equal'],
                             },
                         },
-                        validate: (value: any, operator: TOperator, error: Ref<string | null>): true | false => {
-                            const binRegex = /^(\d{6})/;
-                            if (!binRegex.test(value)) {
-                                error.value = 'Invalid bin';
-                                return false;
-                            }
-                            return true;
+                        validate: (value: any, operator: TOperator): Promise<string | null> => {
+                            return new Promise((resolve) => {
+                                const binRegex = /^\d{6}$/;
+                                if (!binRegex.test(value)) {
+                                    resolve('Invalid bin');
+                                } else {
+                                    resolve(null);
+                                }
+                            });
                         },
                     },
                 ],
@@ -247,12 +249,10 @@ describe('SFilter', () => {
                                 operators: ['between', 'notBetween'],
                             },
                         },
-                        validate: (value: any, operator: TOperator, error: Ref<string | null>): true | false => {
-                            if (operator == 'between' && parseFloat(value[0]) > parseFloat(value[1])) {
-                                error.value = 'Invalid amount range';
-                                return false;
-                            }
-                            return true;
+                        validate: (value: any, operator: TOperator): string | null => {
+                            return operator == 'between' && parseFloat(value[0]) > parseFloat(value[1])
+                                ? 'Invalid amount range'
+                                : null;
                         },
                     },
                 ],

--- a/src/components/spartan/SFilter/elements/SelectFilterDialog.vue
+++ b/src/components/spartan/SFilter/elements/SelectFilterDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { translator } from '@/helpers';
-import { SButton, SCaption, SPopover } from '../..';
+import { SButton, SPopover } from '../..';
 import { useContext } from '../context';
 import { ChevronDownIcon } from '@heroicons/vue/20/solid';
 import { computed, ref, watch } from 'vue';
@@ -112,9 +112,8 @@ const isValid = computed(() => !error.value);
             :is="interfaceComponents[tempInterface]"
             v-model="value"
             :config="tempInterfaceConfig"
-            :error="!isValid"
+            :error-text="error"
         />
-        <SCaption v-if="!isValid" class="-mt-1" :text="error" />
 
         <div class="flex gap-3">
             <SButton class="w-full" variant="secondary" @click="$emit('close')">{{ t('cancelBtn') }}</SButton>

--- a/src/components/spartan/SFilter/elements/SelectFilterDialog.vue
+++ b/src/components/spartan/SFilter/elements/SelectFilterDialog.vue
@@ -53,19 +53,13 @@ const add = () => {
 
 const disabled = computed(() => (!value.value || value.value.length === 0) && tempInterface.value !== 'none');
 
-const validate = (value: any) => {
+const validate = async (value: any) => {
     const empty = Array.isArray(value) ? value.length === 0 : [undefined, null, ''].includes(value);
     if (!field.validate || empty) {
         error.value = null;
         return;
     }
-    const result = field.validate(value, tempOperator.value);
-
-    if (result && typeof result === 'object' && typeof result.then === 'function') {
-        result.then((errMessage: string | null) => (error.value = errMessage));
-    } else {
-        error.value = result;
-    }
+    error.value = await field.validate(value, tempOperator.value);
 };
 
 watch(

--- a/src/components/spartan/SFilter/elements/SelectFilterDialog.vue
+++ b/src/components/spartan/SFilter/elements/SelectFilterDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { translator } from '@/helpers';
-import { SButton, SPopover } from '../..';
+import { SButton, SCaption, SPopover } from '../..';
 import { useContext } from '../context';
 import { ChevronDownIcon } from '@heroicons/vue/20/solid';
 import { computed, ref } from 'vue';
@@ -40,6 +40,8 @@ const selectOperator = (newOperator: TOperator, close: () => void) => {
 
 const value = ref(field.state?.value);
 
+const error = ref();
+
 const add = () => {
     if (!tempOperator.value) return;
     field.state = {
@@ -50,6 +52,14 @@ const add = () => {
 };
 
 const disabled = computed(() => (!value.value || value.value.length === 0) && tempInterface.value !== 'none');
+
+const isValid = computed(() => {
+    if (field.validate) {
+        const hasValue = Array.isArray(value) ? value.value.length > 0 : ![undefined, null, ''].includes(value.value);
+        return hasValue ? field.validate(value.value, tempOperator.value, error) : true;
+    }
+    return true;
+});
 </script>
 
 <template>
@@ -83,13 +93,19 @@ const disabled = computed(() => (!value.value || value.value.length === 0) && te
             </SPopover>
         </div>
 
-        <component :is="interfaceComponents[tempInterface]" v-model="value" :config="tempInterfaceConfig" />
+        <component
+            :is="interfaceComponents[tempInterface]"
+            v-model="value"
+            :config="tempInterfaceConfig"
+            :error="!isValid"
+        />
+        <SCaption v-if="!isValid" class="-mt-1" :text="error" />
 
         <div class="flex gap-3">
             <SButton class="w-full" variant="secondary" @click="$emit('close')">{{ t('cancelBtn') }}</SButton>
             <SButton
                 :class="['w-full', disabled && 'pointer-events-none opacity-50']"
-                :disabled="disabled"
+                :disabled="disabled || !isValid"
                 @click="add"
             >
                 {{ t('addBtn') }}

--- a/src/components/spartan/SFilter/interfaces/IOneInput.vue
+++ b/src/components/spartan/SFilter/interfaces/IOneInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { SInput, SInputAmount } from '@spartan';
+import { SInputAmountBlock, SInputBlock } from '@spartan';
 import type { IInputConfig } from './types';
 import { translator } from '@/helpers';
 
@@ -9,7 +9,7 @@ const emit = defineEmits(['update:modelValue']);
 const props = defineProps<{
     modelValue?: string | number;
     config: IInputConfig;
-    error?: boolean;
+    errorText?: string;
 }>();
 
 const { t } = translator('filter');
@@ -29,7 +29,7 @@ const updateCurrency = (currency?: string) => {
 </script>
 
 <template>
-    <SInputAmount
+    <SInputAmountBlock
         v-if="config.inputType === 'amount'"
         v-model="value as number"
         :currency="config.currency ?? config.currencies![0]"
@@ -37,14 +37,14 @@ const updateCurrency = (currency?: string) => {
         :type="config.inputType"
         :placeholder="t('inputSelectorPlaceholder')"
         :minor-unit-mode="config.minorUnitMode"
-        :error="error === true"
+        :error-text="errorText"
         @update:currency="updateCurrency"
     />
-    <SInput
+    <SInputBlock
         v-else
         v-model="value"
         :type="config.inputType"
         :placeholder="t('inputSelectorPlaceholder')"
-        :error="error === true"
+        :error-text="errorText"
     />
 </template>

--- a/src/components/spartan/SFilter/interfaces/IOneInput.vue
+++ b/src/components/spartan/SFilter/interfaces/IOneInput.vue
@@ -9,6 +9,7 @@ const emit = defineEmits(['update:modelValue']);
 const props = defineProps<{
     modelValue?: string | number;
     config: IInputConfig;
+    error?: boolean;
 }>();
 
 const { t } = translator('filter');
@@ -36,7 +37,14 @@ const updateCurrency = (currency?: string) => {
         :type="config.inputType"
         :placeholder="t('inputSelectorPlaceholder')"
         :minor-unit-mode="config.minorUnitMode"
+        :error="error === true"
         @update:currency="updateCurrency"
     />
-    <SInput v-else v-model="value" :type="config.inputType" :placeholder="t('inputSelectorPlaceholder')" />
+    <SInput
+        v-else
+        v-model="value"
+        :type="config.inputType"
+        :placeholder="t('inputSelectorPlaceholder')"
+        :error="error === true"
+    />
 </template>

--- a/src/components/spartan/SFilter/interfaces/ITwoInputs.vue
+++ b/src/components/spartan/SFilter/interfaces/ITwoInputs.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
-import { SInput, SInputAmount } from '@spartan';
+import { SInputAmount, SInput } from '@spartan';
+import { BlockWrapper } from '@internal';
 import type { IInputConfig } from './types';
 import { translator } from '@/helpers';
 
@@ -9,7 +10,7 @@ const emit = defineEmits(['update:modelValue']);
 const props = defineProps<{
     modelValue?: string[] | number[];
     config: IInputConfig;
-    error?: boolean;
+    errorText?: string;
 }>();
 
 const { t } = translator('filter');
@@ -27,45 +28,46 @@ const updateCurrency = (currency?: string) => {
 </script>
 
 <template>
-    <div class="flex gap-4">
-        <SInputAmount
-            v-if="config.inputType === 'amount'"
-            v-model="value1 as number"
-            :currency="config.currency ?? config.currencies![0]"
-            :currencies="config.currencies"
-            :type="config.inputType"
-            :placeholder="t('inputSelectorPlaceholder')"
-            :minor-unit-mode="config.minorUnitMode"
-            :error="error === true"
-            @update:currency="updateCurrency"
-        />
-        <SInput
-            v-else
-            v-model="value1"
-            class="w-48"
-            :type="config.inputType"
-            :placeholder="t('inputSelectorPlaceholder')"
-            :error="error === true"
-        />
-
-        <SInputAmount
-            v-if="config.inputType === 'amount'"
-            v-model="value2 as number"
-            :currency="config.currency ?? config.currencies![0]"
-            :currencies="config.currencies"
-            :type="config.inputType"
-            :placeholder="t('inputSelectorPlaceholder')"
-            :minor-unit-mode="config.minorUnitMode"
-            :error="error === true"
-            @update:currency="updateCurrency"
-        />
-        <SInput
-            v-else
-            v-model="value2"
-            class="w-48"
-            :type="config.inputType"
-            :placeholder="t('inputSelectorPlaceholder')"
-            :error="error === true"
-        />
-    </div>
+    <BlockWrapper :error-text="errorText">
+        <div class="flex gap-4">
+            <SInputAmount
+                v-if="config.inputType === 'amount'"
+                v-model="value1 as number"
+                :currency="config.currency ?? config.currencies![0]"
+                :currencies="config.currencies"
+                :type="config.inputType"
+                :placeholder="t('inputSelectorPlaceholder')"
+                :minor-unit-mode="config.minorUnitMode"
+                :error="!!errorText"
+                @update:currency="updateCurrency"
+            />
+            <SInput
+                v-else
+                v-model="value1"
+                class="w-48"
+                :type="config.inputType"
+                :placeholder="t('inputSelectorPlaceholder')"
+                :error="!!errorText"
+            />
+            <SInputAmount
+                v-if="config.inputType === 'amount'"
+                v-model="value2 as number"
+                :currency="config.currency ?? config.currencies![0]"
+                :currencies="config.currencies"
+                :type="config.inputType"
+                :placeholder="t('inputSelectorPlaceholder')"
+                :minor-unit-mode="config.minorUnitMode"
+                :error="!!errorText"
+                @update:currency="updateCurrency"
+            />
+            <SInput
+                v-else
+                v-model="value2"
+                class="w-48"
+                :type="config.inputType"
+                :placeholder="t('inputSelectorPlaceholder')"
+                :error="!!errorText"
+            />
+        </div>
+    </BlockWrapper>
 </template>

--- a/src/components/spartan/SFilter/interfaces/ITwoInputs.vue
+++ b/src/components/spartan/SFilter/interfaces/ITwoInputs.vue
@@ -9,6 +9,7 @@ const emit = defineEmits(['update:modelValue']);
 const props = defineProps<{
     modelValue?: string[] | number[];
     config: IInputConfig;
+    error?: boolean;
 }>();
 
 const { t } = translator('filter');
@@ -35,6 +36,7 @@ const updateCurrency = (currency?: string) => {
             :type="config.inputType"
             :placeholder="t('inputSelectorPlaceholder')"
             :minor-unit-mode="config.minorUnitMode"
+            :error="error === true"
             @update:currency="updateCurrency"
         />
         <SInput
@@ -43,6 +45,7 @@ const updateCurrency = (currency?: string) => {
             class="w-48"
             :type="config.inputType"
             :placeholder="t('inputSelectorPlaceholder')"
+            :error="error === true"
         />
 
         <SInputAmount
@@ -53,6 +56,7 @@ const updateCurrency = (currency?: string) => {
             :type="config.inputType"
             :placeholder="t('inputSelectorPlaceholder')"
             :minor-unit-mode="config.minorUnitMode"
+            :error="error === true"
             @update:currency="updateCurrency"
         />
         <SInput
@@ -61,6 +65,7 @@ const updateCurrency = (currency?: string) => {
             class="w-48"
             :type="config.inputType"
             :placeholder="t('inputSelectorPlaceholder')"
+            :error="error === true"
         />
     </div>
 </template>

--- a/src/components/spartan/SFilter/types.ts
+++ b/src/components/spartan/SFilter/types.ts
@@ -45,7 +45,7 @@ export type TField = {
         operator: TOperator;
         value: any;
     };
-    validate?: (value: any, operator: TOperator, error: Ref<string | null>) => boolean;
+    validate?: (value: any, operator: TOperator) => string | null | Promise<string | null>;
 };
 
 export type TInterfaces = {

--- a/src/components/spartan/SFilter/types.ts
+++ b/src/components/spartan/SFilter/types.ts
@@ -7,6 +7,7 @@ import {
     existenceOperators,
 } from './constants';
 import { Currencies } from '@/constants';
+import type { Ref } from 'vue';
 
 // Operator types
 export type TComparisonOperator = (typeof comparisonOperators)[number];
@@ -44,6 +45,7 @@ export type TField = {
         operator: TOperator;
         value: any;
     };
+    validate?: (value: any, operator: TOperator, error: Ref<string | null>) => boolean;
 };
 
 export type TInterfaces = {


### PR DESCRIPTION
Add "validate" option to "fields" structure of SFilter.

It allows to configure a callback to validate filter data and define error message. The new option was not considered for selection type fields.

Eg. Integrate new option using VeeValidate

`
validate: async (value) => {
      const validation = await validate(value, 'length:6', {name: 'Bin' });
      return !validation.valid ? validation.errors[0] : null;
}
`

<img width="378" height="200" alt="Eg. validate filter" src="https://github.com/user-attachments/assets/fd17b11c-4252-4129-9688-30e5d7b1b51e" />



