### PR TITLE
refactor: clear the mechanical SonarQube findings

### DIFF
--- a/src/components/spartan/SBadge/types.ts
+++ b/src/components/spartan/SBadge/types.ts
@@ -1,9 +1,7 @@
 import type { HTMLAttributes } from 'vue';
 import type { TBadgeStyles } from './styles';
 
-export type TBadgeEmits = {
-    (event: 'removed'): void;
-};
+export type TBadgeEmits = (event: 'removed') => void;
 
 export type TBadgeProps = {
     /**

--- a/src/components/spartan/SButton/types.ts
+++ b/src/components/spartan/SButton/types.ts
@@ -43,7 +43,7 @@ export type TButtonProps = {
      * @en Defines the border radius of the button.
      * @es Define el radio de borde del botón.
      */
-    rounded?: TButtonStyles['rounded'];
+    rounded?: NonNullable<TButtonStyles['rounded']>;
 
     /**
      * @en Defines the size of the button.

--- a/src/components/spartan/SCardBrand/SCardBrand.test.ts
+++ b/src/components/spartan/SCardBrand/SCardBrand.test.ts
@@ -40,7 +40,7 @@ describe('SCardBrand', () => {
     });
 
     test('Constants brandName matches assets exports', () => {
-        expect(brandName.length).toBe(brandNames.length);
+        expect(brandName).toHaveLength(brandNames.length);
         brandName.forEach((name) => {
             expect(brandNames).toContain(name);
         });

--- a/src/components/spartan/SColorSwitch/types.ts
+++ b/src/components/spartan/SColorSwitch/types.ts
@@ -5,7 +5,5 @@ export type TColorSwitchProps = {
     modelValue?: TColorSwitchMode;
 };
 
-export type TColorSwitchEmits = {
-    /** @en Emitted when the color mode changes. @es Se emite cuando el modo de color cambia. */
-    (e: 'update:modelValue', value: TColorSwitchMode): void;
-};
+/** @en Emitted when the color mode changes. @es Se emite cuando el modo de color cambia. */
+export type TColorSwitchEmits = (e: 'update:modelValue', value: TColorSwitchMode) => void;

--- a/src/components/spartan/SCopy/types.ts
+++ b/src/components/spartan/SCopy/types.ts
@@ -1,10 +1,8 @@
-export type TCopyEmits = {
-    /**
-     * @en Emitted when the text is copied to the clipboard.
-     * @es Se emite cuando el texto se copia al portapapeles.
-     */
-    (event: 'copied', value: string): void;
-};
+/**
+ * @en Emitted when the text is copied to the clipboard.
+ * @es Se emite cuando el texto se copia al portapapeles.
+ */
+export type TCopyEmits = (event: 'copied', value: string) => void;
 
 export type TCopyProps = {
     /**

--- a/src/components/spartan/SDTable/SDTable.test.ts
+++ b/src/components/spartan/SDTable/SDTable.test.ts
@@ -356,7 +356,7 @@ describe('SDTable', () => {
         await waitFor(() => {
             // Only one expander button per row (header + 1 row)
             const buttons = screen.getAllByRole('button');
-            expect(buttons.length).toBe(2);
+            expect(buttons).toHaveLength(2);
         });
     });
 
@@ -371,7 +371,7 @@ describe('SDTable', () => {
 
         await waitFor(() => {
             // Only the named column should render as a header
-            expect(screen.getAllByRole('columnheader').length).toBe(1);
+            expect(screen.getAllByRole('columnheader')).toHaveLength(1);
         });
     });
 

--- a/src/components/spartan/SDTable/SDTable.vue
+++ b/src/components/spartan/SDTable/SDTable.vue
@@ -40,10 +40,6 @@ const ptPaginator = extractor(pt.value.paginator);
             <table data-s-table v-bind="tableProps" :class="twMerge('w-full', tableClass)">
                 <TableHead v-bind="{ ptThead }" />
                 <TableBody />
-                <!-- <template #expansion="{ row }">
-                        <slot name="expansion" v-bind="{ row }" />
-                    </template>
-                </TableBody> -->
             </table>
         </div>
 

--- a/src/components/spartan/SFilter/interfaces/IOptions.vue
+++ b/src/components/spartan/SFilter/interfaces/IOptions.vue
@@ -74,15 +74,8 @@ const clear = () => {
                         {{ getOptionLabel(option) }}
                     </SBadge>
                 </template>
-                <!--
-                    `id="input-search"` used to live here. It labelled nothing — no
-                    `<label for>` referenced it — and it was a constant, so two option
-                    fields on a page produced duplicate DOM ids. It only ever served as
-                    a test hook, which `data-s-filter-search` now does honestly.
-
-                    The placeholder disappears once something is selected, so it cannot
-                    be the accessible name either.
-                -->
+                <!-- Named for screen readers via aria-label, since the placeholder is -->
+                <!-- cleared on selection. Tests target the data-s-filter-search hook. -->
                 <input
                     v-model="search"
                     data-s-filter-search

--- a/src/components/spartan/SInputDate/types.ts
+++ b/src/components/spartan/SInputDate/types.ts
@@ -116,10 +116,8 @@ export type TInputDateProps = {
     showWeek?: boolean;
 };
 
-export type TInputDateEmits = {
-    /**
-     * @en Emitted when the selected date value changes.
-     * @es Se emite cuando el valor de la fecha seleccionada cambia.
-     */
-    (event: 'update:modelValue', value: TDateValue): void;
-};
+/**
+ * @en Emitted when the selected date value changes.
+ * @es Se emite cuando el valor de la fecha seleccionada cambia.
+ */
+export type TInputDateEmits = (event: 'update:modelValue', value: TDateValue) => void;

--- a/src/components/spartan/SInputIncrement/types.ts
+++ b/src/components/spartan/SInputIncrement/types.ts
@@ -1,12 +1,10 @@
 import type { HTMLAttributes } from 'vue';
 
-export type TInputIncrementEmits = {
-    /**
-     * @en Emitted when the numeric value changes.
-     * @es Se emite cuando el valor numérico cambia.
-     */
-    (event: 'update:modelValue', value: number): void;
-};
+/**
+ * @en Emitted when the numeric value changes.
+ * @es Se emite cuando el valor numérico cambia.
+ */
+export type TInputIncrementEmits = (event: 'update:modelValue', value: number) => void;
 
 export type TInputIncrementProps = {
     /**

--- a/src/components/spartan/SInputOtp/SInputOtpItem.vue
+++ b/src/components/spartan/SInputOtp/SInputOtpItem.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useContext } from './api';
 import { inputOtpItemStyles, inputOtpItemTextStyles } from './styles';
 import { twMerge } from 'tailwind-merge';
 import type { TInputOtpItemProps } from './types';
-import { computed } from 'vue';
 
 defineProps<TInputOtpItemProps>();
 

--- a/src/components/spartan/SInputOtp/types.ts
+++ b/src/components/spartan/SInputOtp/types.ts
@@ -1,12 +1,10 @@
 import type { HTMLAttributes } from 'vue';
 
-export type TInputOtpEmits = {
-    /**
-     * @en Emitted when the OTP value changes.
-     * @es Se emite cuando el valor OTP cambia.
-     */
-    (event: 'update:modelValue', value: string): void;
-};
+/**
+ * @en Emitted when the OTP value changes.
+ * @es Se emite cuando el valor OTP cambia.
+ */
+export type TInputOtpEmits = (event: 'update:modelValue', value: string) => void;
 
 export type TInputOtpProps = {
     /**

--- a/src/components/spartan/SInputPassword/SInputPassword.test.ts
+++ b/src/components/spartan/SInputPassword/SInputPassword.test.ts
@@ -44,7 +44,7 @@ describe('SInputPassword', () => {
         await user.type(input, 'abc');
 
         expect(emitted()['update:modelValue']).toBeTruthy();
-        expect(emitted()['update:modelValue'].length).toBe(3);
+        expect(emitted()['update:modelValue']).toHaveLength(3);
     });
 
     test('Emits isValid and state when rules are provided', async () => {
@@ -224,7 +224,7 @@ describe('SInputPasswordPanel', () => {
         });
 
         const items = container.querySelectorAll('.flex.items-center.gap-2');
-        expect(items.length).toBe(3);
+        expect(items).toHaveLength(3);
     });
 
     test('Applies valid color when rule passes', () => {

--- a/src/components/spartan/SInputTag/types.ts
+++ b/src/components/spartan/SInputTag/types.ts
@@ -55,10 +55,8 @@ export type TInputTagProps = {
     type?: string;
 };
 
-export type TInputTagEmits = {
-    /**
-     * @en Emitted when the tags array changes (tag added or removed).
-     * @es Se emite cuando el arreglo de etiquetas cambia (etiqueta agregada o eliminada).
-     */
-    (event: 'update:modelValue', value: string[]): void;
-};
+/**
+ * @en Emitted when the tags array changes (tag added or removed).
+ * @es Se emite cuando el arreglo de etiquetas cambia (etiqueta agregada o eliminada).
+ */
+export type TInputTagEmits = (event: 'update:modelValue', value: string[]) => void;

--- a/src/components/spartan/SModalConfirm/SModalConfirm.vue
+++ b/src/components/spartan/SModalConfirm/SModalConfirm.vue
@@ -13,9 +13,8 @@ export default {
 import { SButton, SModalCard } from '@spartan';
 import type { TModalProps, TCardProps } from '@spartan';
 import { computed } from 'vue';
-import { translator } from '@/helpers';
+import { translator, hasSlotContent } from '@/helpers';
 import type { TModalConfirmEmits, TModalConfirmProps } from './types';
-import { hasSlotContent } from '@/helpers';
 
 const emit = defineEmits<TModalConfirmEmits>();
 

--- a/src/components/spartan/SPaginator/SPaginator.test.ts
+++ b/src/components/spartan/SPaginator/SPaginator.test.ts
@@ -38,7 +38,7 @@ describe('SPaginator', () => {
         const nextButton = screen.getByRole('button', { name: /next/i });
 
         // Assert
-        expect(screen.getAllByRole('button', { name: '...' }).length).toBe(2);
+        expect(screen.getAllByRole('button', { name: '...' })).toHaveLength(2);
         screen.getByRole('button', { name: '1' });
 
         screen.getByRole('button', { name: '13' });
@@ -56,7 +56,7 @@ describe('SPaginator', () => {
         await user.click(nextButton);
         await user.click(nextButton);
 
-        expect(screen.getAllByRole('button', { name: '...' }).length).toBe(1);
+        expect(screen.getAllByRole('button', { name: '...' })).toHaveLength(1);
         screen.getByRole('button', { name: '1' });
 
         screen.getByRole('button', { name: '17' });

--- a/src/components/spartan/SPaginator/SPaginator.vue
+++ b/src/components/spartan/SPaginator/SPaginator.vue
@@ -126,32 +126,26 @@ const vPage = computed(() => {
     return undefined;
 });
 
-const vPages = computed(() => {
+const vPages = computed<(string | number)[] | number>(() => {
     if (!vCount.value || !vPage.value) return [];
-
-    let arr: (string | number)[] = [];
 
     if (vCount.value <= vQuantity.value * 2 + 5) return vCount.value;
 
     if (vPage.value - vQuantity.value < 4) {
-        arr = Array.from({ length: vQuantity.value * 2 + 3 }, (_, i) => i + 1);
-        arr.push('...');
-        arr.push(vCount.value);
-    } else if (vCount.value - vPage.value - vQuantity.value < 3) {
-        arr.push(1);
-        arr.push('...');
-        arr = arr.concat(
-            Array.from({ length: vQuantity.value * 2 + 3 }, (_, i) => vCount.value! - vQuantity.value * 2 - 2 + i),
-        );
-    } else {
-        arr.push(1);
-        arr.push('...');
-        arr = arr.concat(Array.from({ length: 1 + vQuantity.value * 2 }, (_, i) => vPage.value! - vQuantity.value + i));
-        arr.push('...');
-        arr.push(vCount.value);
+        const head = Array.from({ length: vQuantity.value * 2 + 3 }, (_, i) => i + 1);
+        return [...head, '...', vCount.value];
     }
 
-    return arr;
+    if (vCount.value - vPage.value - vQuantity.value < 3) {
+        const tail = Array.from(
+            { length: vQuantity.value * 2 + 3 },
+            (_, i) => vCount.value! - vQuantity.value * 2 - 2 + i,
+        );
+        return [1, '...', ...tail];
+    }
+
+    const middle = Array.from({ length: 1 + vQuantity.value * 2 }, (_, i) => vPage.value! - vQuantity.value + i);
+    return [1, '...', ...middle, '...', vCount.value];
 });
 
 const vCanGoPrev = computed(() => {

--- a/src/components/spartan/SRadio/types.ts
+++ b/src/components/spartan/SRadio/types.ts
@@ -1,6 +1,4 @@
-export type TRadioEmits = {
-    (event: 'update:modelValue', value: boolean | string): void;
-};
+export type TRadioEmits = (event: 'update:modelValue', value: boolean | string) => void;
 
 export type TRadioProps = {
     /**

--- a/src/components/spartan/SRadioGroup/types.ts
+++ b/src/components/spartan/SRadioGroup/types.ts
@@ -1,6 +1,4 @@
-export type TRadioGroupEmits = {
-    (event: 'update:modelValue', value: string): void;
-};
+export type TRadioGroupEmits = (event: 'update:modelValue', value: string) => void;
 
 export type TRadioGroupProps = {
     /**

--- a/src/components/spartan/SSelect/types.ts
+++ b/src/components/spartan/SSelect/types.ts
@@ -1,13 +1,11 @@
 import type { TRounded } from '@/helpers';
 import type { HTMLAttributes } from 'vue';
 
-export type TSelectEmits = {
-    /**
-     * @en Emitted when the selected value changes.
-     * @es Se emite cuando el valor seleccionado cambia.
-     */
-    (e: 'update:modelValue', value: string | number | undefined): void;
-};
+/**
+ * @en Emitted when the selected value changes.
+ * @es Se emite cuando el valor seleccionado cambia.
+ */
+export type TSelectEmits = (e: 'update:modelValue', value: string | number | undefined) => void;
 
 export type TSelectProps = {
     /**

--- a/src/components/spartan/SSidebar/SSidebar.test.ts
+++ b/src/components/spartan/SSidebar/SSidebar.test.ts
@@ -46,7 +46,7 @@ describe('SSidebar', () => {
         screen.getByRole('complementary');
         screen.getByRole('navigation');
         screen.getByRole('list');
-        expect(screen.getAllByRole('listitem').length).toBe(3);
+        expect(screen.getAllByRole('listitem')).toHaveLength(3);
         screen.getByRole('button', { name: 'FirstLink' });
         screen.getByRole('button', { name: 'SecondLink' });
         screen.getByRole('button', { name: 'ThirdLink' });
@@ -72,7 +72,7 @@ describe('SSidebar', () => {
         screen.getByRole('complementary');
         screen.getByRole('navigation');
         screen.getByRole('list');
-        expect(screen.getAllByRole('listitem').length).toBe(4);
+        expect(screen.getAllByRole('listitem')).toHaveLength(4);
         screen.getByRole('button', { name: 'ThirdLink' });
     });
 

--- a/src/components/spartan/SSidebar/types.ts
+++ b/src/components/spartan/SSidebar/types.ts
@@ -1,8 +1,6 @@
 import type { Component, FunctionalComponent } from 'vue';
 
-export type TSidebarEmits = {
-    (event: 'update:modelValue', value?: string): void;
-};
+export type TSidebarEmits = (event: 'update:modelValue', value?: string) => void;
 
 export type TSidebarProps = {
     modelValue: string;

--- a/src/components/spartan/SSwitch/types.ts
+++ b/src/components/spartan/SSwitch/types.ts
@@ -1,8 +1,6 @@
 import type { FunctionalComponent } from 'vue';
 
-export type TSwitchEmits = {
-    (event: 'update:modelValue', value: boolean): void;
-};
+export type TSwitchEmits = (event: 'update:modelValue', value: boolean) => void;
 
 export type TSwitchProps = {
     /**

--- a/src/components/spartan/STab/STabItem.vue
+++ b/src/components/spartan/STab/STabItem.vue
@@ -14,7 +14,6 @@ const [itemClass, itemProps] = extractor(pt.value.item);
 </script>
 
 <template>
-    <!-- <li :class="context.full ? 'w-full' : ''"> -->
     <li data-s-item v-bind="itemProps" :class="twMerge(itemClass)">
         <component
             :is="context.variant.item"

--- a/src/components/spartan/STab/types.ts
+++ b/src/components/spartan/STab/types.ts
@@ -46,9 +46,7 @@ export type TTabProps = {
     class?: string;
 };
 
-export type TTabEmits = {
-    (event: 'update:modelValue', value?: string): void;
-};
+export type TTabEmits = (event: 'update:modelValue', value?: string) => void;
 
 export type TTabItemProps = {
     /**

--- a/src/components/spartan/STemplateHeaderTable/types.ts
+++ b/src/components/spartan/STemplateHeaderTable/types.ts
@@ -6,10 +6,8 @@ export type TTemplateHeaderTableProps = {
     title: string;
 };
 
-export type TTemplateHeaderTableEmits = {
-    /**
-     * @en Emitted when the user submits a search query.
-     * @es Se emite cuando el usuario envía una consulta de búsqueda.
-     */
-    (e: 'search', query: string): void;
-};
+/**
+ * @en Emitted when the user submits a search query.
+ * @es Se emite cuando el usuario envía una consulta de búsqueda.
+ */
+export type TTemplateHeaderTableEmits = (e: 'search', query: string) => void;

--- a/src/components/spartan/STextArea/types.ts
+++ b/src/components/spartan/STextArea/types.ts
@@ -26,10 +26,8 @@ export type TTextAreaProps = {
     disabled?: boolean;
 };
 
-export type TTextAreaEmits = {
-    /**
-     * @en Emitted when the textarea content changes.
-     * @es Se emite cuando el contenido del textarea cambia.
-     */
-    (e: 'update:modelValue', value: string): void;
-};
+/**
+ * @en Emitted when the textarea content changes.
+ * @es Se emite cuando el contenido del textarea cambia.
+ */
+export type TTextAreaEmits = (e: 'update:modelValue', value: string) => void;

--- a/src/components/spartan/SToast/SToast.vue
+++ b/src/components/spartan/SToast/SToast.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { CheckCircleIcon, XCircleIcon, ExclamationCircleIcon } from '@heroicons/vue/24/outline';
-import { XMarkIcon } from '@heroicons/vue/24/outline';
+import { CheckCircleIcon, XCircleIcon, ExclamationCircleIcon, XMarkIcon } from '@heroicons/vue/24/outline';
 import { computed } from 'vue';
 import { hasSlotContent } from '@/helpers';
 import type { TToastProps, TToastEmits } from './types';

--- a/src/components/spartan/SToast/toast.ts
+++ b/src/components/spartan/SToast/toast.ts
@@ -1,9 +1,9 @@
 import { markRaw } from 'vue';
 import SToast from './SToast.vue';
-import { toast as vsToast, Toaster as SToaster, type ToasterProps } from 'vue-sonner';
+import { toast as vsToast, type ToasterProps } from 'vue-sonner';
 import type { TToastProps } from './types';
 
-export { SToaster };
+export { Toaster as SToaster } from 'vue-sonner';
 export const toast = (props: TToastProps & ToasterProps) => {
     const { type, title, description, closeable, leftBorder, ...toastProps } = props;
     const componentProps = { type, title, description, closeable, leftBorder };

--- a/src/components/spartan/SToast/types.ts
+++ b/src/components/spartan/SToast/types.ts
@@ -1,8 +1,6 @@
 import type { HTMLAttributes } from 'vue';
 
-export type TToastEmits = {
-    (event: 'closeToast'): void;
-};
+export type TToastEmits = (event: 'closeToast') => void;
 
 export type TToastProps = {
     /**

--- a/src/components/spartan/STooltip/types.ts
+++ b/src/components/spartan/STooltip/types.ts
@@ -19,7 +19,7 @@ export type TTooltipProps = {
      * @es Posición preferida del tooltip relativa al disparador.
      * @default 'bottom'
      */
-    placement?: TPopoverProps['placement'];
+    placement?: NonNullable<TPopoverProps['placement']>;
 
     /**
      * @en Whether to display an arrow pointing to the trigger.
@@ -32,7 +32,7 @@ export type TTooltipProps = {
      * @en Distance in pixels between the trigger and the tooltip.
      * @es Distancia en píxeles entre el disparador y el tooltip.
      */
-    offset?: TPopoverProps['offset'];
+    offset?: NonNullable<TPopoverProps['offset']>;
 
     /**
      * @en Disables automatic flip positioning.


### PR DESCRIPTION
Working from the SonarCloud list, the ones that were unambiguous and safe:

- 16 single-signature emit types converted from a call-signature object literal to a function type (`{ (e): void }` -> `(e) => void`). Verified `defineEmits` still infers every event: typecheck clean, 1032 tests pass. JSDoc preserved, moved above each alias.
- 9 `expect(x.length).toBe(n)` -> `expect(x).toHaveLength(n)` across five test files. More specific failure output; no behaviour change.
- Redundant `?` + resolved `| undefined` on `SButton.rounded`, `STooltip.placement` and `STooltip.offset` wrapped in `NonNullable<...>`, matching the pattern already used for `variant`/`size` in the same files.
- Consolidated duplicate imports in SToast.vue (@heroicons), SModalConfirm.vue (@/helpers) and SInputOtpItem.vue (vue).
- SToast re-exports Toaster with `export { Toaster as SToaster } from 'vue-sonner'` instead of importing then re-exporting.
- Removed dead commented code in SDTable.vue and STabItem.vue. Trimmed the IOptions.vue comment so it no longer reads as commented-out markup (Sonar was flagging the `id="input-search"` prose as code).
- SPaginator's page-range builder rewritten: each branch returns a single array literal instead of a sequence of `arr.push()` calls, which also drops the useless initial assignment. Still 100% branch coverage (page 3/16/4 cover start/end/middle).

Not touched, deliberately: the `Type literal ... call signature` conversion is safe only for single-signature emit types; none here had multiple. The SFilter `SFilterAmountOperator = SFilterNumberOperator` alias stays — it is a documented semantic alias, not redundant.