### PR TITLE
test: make implicit assertions explicit (SonarQube assertions-in-tests)

### DIFF
--- a/src/components/spartan/SAlert/SAlert.test.ts
+++ b/src/components/spartan/SAlert/SAlert.test.ts
@@ -21,7 +21,7 @@ describe('SAlert', () => {
         render(SAlert, { slots: { default: 'This is an alert message' } });
 
         // Assert
-        screen.getByText('This is an alert message');
+        expect(screen.getByText('This is an alert message')).toBeInTheDocument();
     });
 
     test('Can be rendered with title', () => {
@@ -39,7 +39,7 @@ describe('SAlert', () => {
         render(SAlert, { props: { description: 'Alert description text' } });
 
         // Assert
-        screen.getByText('Alert description text');
+        expect(screen.getByText('Alert description text')).toBeInTheDocument();
     });
 
     test('Can be rendered with title and description', () => {
@@ -52,8 +52,8 @@ describe('SAlert', () => {
         });
 
         // Assert
-        screen.getByRole('heading', { level: 3, name: 'Alert Title' });
-        screen.getByText('Alert description text');
+        expect(screen.getByRole('heading', { level: 3, name: 'Alert Title' })).toBeInTheDocument();
+        expect(screen.getByText('Alert description text')).toBeInTheDocument();
     });
 
     test('Can be rendered with icon', () => {
@@ -196,8 +196,9 @@ describe('SAlert', () => {
         });
 
         // Assert
-        screen.getByText('Description text');
-        screen.queryByText('Slot content'); // Should not render slot when description exists
+        expect(screen.getByText('Description text')).toBeInTheDocument();
+        // The default slot is not rendered while a description is present.
+        expect(screen.queryByText('Slot content')).not.toBeInTheDocument();
     });
 
     test('Can render slot content when title is provided but not description', () => {
@@ -208,7 +209,7 @@ describe('SAlert', () => {
         });
 
         // Assert
-        screen.getByRole('heading', { level: 3, name: 'Alert Title' });
+        expect(screen.getByRole('heading', { level: 3, name: 'Alert Title' })).toBeInTheDocument();
         const slotContent = screen.getByText('Slot content instead of description');
         expect(slotContent.parentElement).toHaveClass('min-w-0 flex-1');
     });

--- a/src/components/spartan/SBreadcrumbs/SBreadcrumbs.test.ts
+++ b/src/components/spartan/SBreadcrumbs/SBreadcrumbs.test.ts
@@ -23,7 +23,7 @@ describe('SBreadcrumbs', () => {
         render(SBreadcrumbs);
 
         // Assert
-        screen.getByRole('navigation', { name: 'Breadcrumb' });
+        expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument();
     });
 
     test('Renders with semantic HTML structure', () => {

--- a/src/components/spartan/SButton/SButton.test.ts
+++ b/src/components/spartan/SButton/SButton.test.ts
@@ -15,7 +15,7 @@ describe('SButton', () => {
     test('Can be rendered with slot content', () => {
         render(SButton, { slots: { default: 'Click me' } });
 
-        screen.getByRole('button', { name: 'Click me' });
+        expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
     });
 
     test('Can be polymorphic', () => {

--- a/src/components/spartan/SCheckbox/SCheckbox.test.ts
+++ b/src/components/spartan/SCheckbox/SCheckbox.test.ts
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 describe('SCheckbox', () => {
     test('Can be rendered', () => {
         render(SCheckbox);
-        screen.getByRole('checkbox');
+        expect(screen.getByRole('checkbox')).toBeInTheDocument();
     });
 
     test('Can be checked', async () => {

--- a/src/components/spartan/SCopy/SCopy.test.ts
+++ b/src/components/spartan/SCopy/SCopy.test.ts
@@ -14,7 +14,7 @@ describe('SCopy', () => {
         });
 
         // Assert
-        screen.getByText('Test Content');
+        expect(screen.getByText('Test Content')).toBeInTheDocument();
     });
 
     test('Can copy a value from slot', async () => {

--- a/src/components/spartan/SDTable/SDTable.test.ts
+++ b/src/components/spartan/SDTable/SDTable.test.ts
@@ -28,15 +28,21 @@ describe('SDTable', () => {
 
         // Assert
         await waitFor(() => {
-            screen.getByRole('columnheader', { name: 'Nombre' });
-            screen.getByRole('columnheader', { name: 'Correo' });
-            screen.getByRole('columnheader', { name: 'Titulo' });
-            screen.getByRole('columnheader', { name: 'Rol' });
+            expect(screen.getByRole('columnheader', { name: 'Nombre' })).toBeInTheDocument();
+            expect(screen.getByRole('columnheader', { name: 'Correo' })).toBeInTheDocument();
+            expect(screen.getByRole('columnheader', { name: 'Titulo' })).toBeInTheDocument();
+            expect(screen.getByRole('columnheader', { name: 'Rol' })).toBeInTheDocument();
 
-            screen.getByRole('cell', { name: 'Lindsay Walton' });
+            expect(screen.getByRole('cell', { name: 'Lindsay Walton' })).toBeInTheDocument();
 
-            screen.getByRole('row', { name: 'Lindsay Walton lindsay.walton@example.com Front-end Developer Member' });
-            screen.getByRole('row', { name: 'Jhon Connor jhon.connor@example.com Back-end Developer Member' });
+            expect(
+                screen.getByRole('row', {
+                    name: 'Lindsay Walton lindsay.walton@example.com Front-end Developer Member',
+                }),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('row', { name: 'Jhon Connor jhon.connor@example.com Back-end Developer Member' }),
+            ).toBeInTheDocument();
         });
     });
 
@@ -254,7 +260,7 @@ describe('SDTable', () => {
         });
 
         await waitFor(() => {
-            screen.getByRole('columnheader', { name: 'Name' });
+            expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
         });
     });
 
@@ -267,7 +273,7 @@ describe('SDTable', () => {
         });
 
         await waitFor(() => {
-            screen.getByRole('cell', { name: 'Alice' });
+            expect(screen.getByRole('cell', { name: 'Alice' })).toBeInTheDocument();
         });
     });
 

--- a/src/components/spartan/SDefinitionTerm/SDefinitionTerm.test.ts
+++ b/src/components/spartan/SDefinitionTerm/SDefinitionTerm.test.ts
@@ -9,7 +9,7 @@ describe('SDefinitionTerm', () => {
         render(SDefinitionTerm);
 
         // Assert
-        screen.getByRole('definition');
+        expect(screen.getByRole('definition')).toBeInTheDocument();
     });
 
     test('Can be rendered with label and descriptions by props', () => {

--- a/src/components/spartan/SDropdown/SDropdown.test.ts
+++ b/src/components/spartan/SDropdown/SDropdown.test.ts
@@ -26,14 +26,14 @@ describe('SDropdown', () => {
         await user.click(screen.getByRole('button', { name: 'Dropdown Button' }));
 
         // Assert
-        screen.getByText('Title');
-        screen.getByText('Description');
+        expect(screen.getByText('Title')).toBeInTheDocument();
+        expect(screen.getByText('Description')).toBeInTheDocument();
 
-        screen.getByText('Option');
-        screen.getByText('Device');
+        expect(screen.getByText('Option')).toBeInTheDocument();
+        expect(screen.getByText('Device')).toBeInTheDocument();
 
-        screen.getByText('Option');
-        screen.getByText('Edit');
+        expect(screen.getByText('Option')).toBeInTheDocument();
+        expect(screen.getByText('Edit')).toBeInTheDocument();
     });
 
     test('Does not toggle when manual is true', async () => {

--- a/src/components/spartan/SPaginator/SPaginator.test.ts
+++ b/src/components/spartan/SPaginator/SPaginator.test.ts
@@ -12,11 +12,11 @@ describe('SPaginator', () => {
         });
 
         // Assert
-        screen.getByRole('button', { name: '1' });
-        screen.getByRole('button', { name: '2' });
-        screen.getByRole('button', { name: '3' });
-        screen.getByRole('button', { name: '...' });
-        screen.getByRole('button', { name: '25' });
+        expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '3' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '...' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '25' })).toBeInTheDocument();
     });
 
     test('Can be emit events', async () => {
@@ -39,17 +39,17 @@ describe('SPaginator', () => {
 
         // Assert
         expect(screen.getAllByRole('button', { name: '...' })).toHaveLength(2);
-        screen.getByRole('button', { name: '1' });
+        expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
 
-        screen.getByRole('button', { name: '13' });
-        screen.getByRole('button', { name: '14' });
-        screen.getByRole('button', { name: '15' });
-        screen.getByRole('button', { name: '16' });
-        screen.getByRole('button', { name: '17' });
-        screen.getByRole('button', { name: '18' });
-        screen.getByRole('button', { name: '19' });
+        expect(screen.getByRole('button', { name: '13' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '14' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '15' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '16' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '17' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '18' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '19' })).toBeInTheDocument();
 
-        screen.getByRole('button', { name: '25' });
+        expect(screen.getByRole('button', { name: '25' })).toBeInTheDocument();
 
         await user.click(nextButton);
         await user.click(nextButton);
@@ -57,17 +57,17 @@ describe('SPaginator', () => {
         await user.click(nextButton);
 
         expect(screen.getAllByRole('button', { name: '...' })).toHaveLength(1);
-        screen.getByRole('button', { name: '1' });
+        expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
 
-        screen.getByRole('button', { name: '17' });
-        screen.getByRole('button', { name: '18' });
-        screen.getByRole('button', { name: '19' });
-        screen.getByRole('button', { name: '20' });
-        screen.getByRole('button', { name: '21' });
-        screen.getByRole('button', { name: '22' });
-        screen.getByRole('button', { name: '23' });
-        screen.getByRole('button', { name: '24' });
-        screen.getByRole('button', { name: '25' });
+        expect(screen.getByRole('button', { name: '17' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '18' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '19' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '20' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '21' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '22' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '23' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '24' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '25' })).toBeInTheDocument();
     });
 
     test('Can be render fully', async () => {
@@ -91,12 +91,12 @@ describe('SPaginator', () => {
         await user.click(button);
 
         // Assert
-        screen.getByRole('button', { name: '1' });
-        screen.getByRole('button', { name: '2' });
-        screen.getByRole('button', { name: '3' });
-        screen.getByRole('button', { name: '4' });
-        screen.getByRole('button', { name: '5' });
-        screen.getByRole('button', { name: '6' });
+        expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '3' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '4' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '5' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '6' })).toBeInTheDocument();
     });
 
     test('Navigates to previous page', async () => {

--- a/src/components/spartan/SPopover/SPopover.test.ts
+++ b/src/components/spartan/SPopover/SPopover.test.ts
@@ -33,7 +33,7 @@ describe('SPopover', () => {
         const button = screen.getByRole('button', { name: 'Reference element' });
         await user.click(button);
 
-        screen.getByText('Hello World!');
+        expect(screen.getByText('Hello World!')).toBeInTheDocument();
     });
 
     test('Toggles via the exposed toggle handler', async () => {

--- a/src/components/spartan/SRadio/SRadio.test.ts
+++ b/src/components/spartan/SRadio/SRadio.test.ts
@@ -17,7 +17,7 @@ describe('SRadio', () => {
 
     test('Can be rendered', () => {
         render(SRadio);
-        screen.getByRole('radio');
+        expect(screen.getByRole('radio')).toBeInTheDocument();
     });
 
     test('Can be checked', async () => {

--- a/src/components/spartan/SRadioGroup/SRadioGroup.test.ts
+++ b/src/components/spartan/SRadioGroup/SRadioGroup.test.ts
@@ -33,7 +33,7 @@ describe('SRadioGroup', () => {
             slots: { default: [option1, option2] },
         });
 
-        screen.getByRole('radiogroup');
+        expect(screen.getByRole('radiogroup')).toBeInTheDocument();
     });
 
     test('Can be checked', async () => {

--- a/src/components/spartan/SSelectBlock/SSelectBlock.test.ts
+++ b/src/components/spartan/SSelectBlock/SSelectBlock.test.ts
@@ -11,7 +11,7 @@ describe('SSelectBlock', () => {
         render(SSelectBlock);
 
         // Assert
-        screen.getByRole('combobox');
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
     });
 
     test('Can be rendered with label', () => {

--- a/src/components/spartan/SSidebar/SSidebar.test.ts
+++ b/src/components/spartan/SSidebar/SSidebar.test.ts
@@ -26,7 +26,7 @@ describe('SSidebar', () => {
         render(SSidebar);
 
         // Assert
-        screen.getByRole('complementary');
+        expect(screen.getByRole('complementary')).toBeInTheDocument();
     });
 
     test('Can be rendered with items', () => {
@@ -43,13 +43,13 @@ describe('SSidebar', () => {
         });
 
         // Assert
-        screen.getByRole('complementary');
-        screen.getByRole('navigation');
-        screen.getByRole('list');
+        expect(screen.getByRole('complementary')).toBeInTheDocument();
+        expect(screen.getByRole('navigation')).toBeInTheDocument();
+        expect(screen.getByRole('list')).toBeInTheDocument();
         expect(screen.getAllByRole('listitem')).toHaveLength(3);
-        screen.getByRole('button', { name: 'FirstLink' });
-        screen.getByRole('button', { name: 'SecondLink' });
-        screen.getByRole('button', { name: 'ThirdLink' });
+        expect(screen.getByRole('button', { name: 'FirstLink' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'SecondLink' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'ThirdLink' })).toBeInTheDocument();
     });
 
     test('Can be rendered with groups', () => {
@@ -69,11 +69,11 @@ describe('SSidebar', () => {
 
         // Assert
         screen.debug();
-        screen.getByRole('complementary');
-        screen.getByRole('navigation');
-        screen.getByRole('list');
+        expect(screen.getByRole('complementary')).toBeInTheDocument();
+        expect(screen.getByRole('navigation')).toBeInTheDocument();
+        expect(screen.getByRole('list')).toBeInTheDocument();
         expect(screen.getAllByRole('listitem')).toHaveLength(4);
-        screen.getByRole('button', { name: 'ThirdLink' });
+        expect(screen.getByRole('button', { name: 'ThirdLink' })).toBeInTheDocument();
     });
 
     test('Can be rendered a header', () => {
@@ -91,7 +91,7 @@ describe('SSidebar', () => {
         });
 
         // Assert
-        screen.getByRole('banner');
+        expect(screen.getByRole('banner')).toBeInTheDocument();
     });
 
     test('Can be rendered a footer', () => {
@@ -109,7 +109,7 @@ describe('SSidebar', () => {
         });
 
         // Assert
-        screen.getByText('Footer');
+        expect(screen.getByText('Footer')).toBeInTheDocument();
     });
 
     test('Renders custom header slot', () => {

--- a/src/components/spartan/SSteps/SSteps.test.ts
+++ b/src/components/spartan/SSteps/SSteps.test.ts
@@ -27,10 +27,10 @@ describe('SSteps', () => {
         });
 
         // Assert
-        screen.getByRole('navigation', { name: 'Progress' });
-        screen.getByRole('link', { name: 'First step' });
-        screen.getByRole('link', { name: 'Second steptest description' });
-        screen.getByRole('link', { name: 'Third step' });
+        expect(screen.getByRole('navigation', { name: 'Progress' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'First step' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Second steptest description' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Third step' })).toBeInTheDocument();
     });
 
     test('Can be rendered with array', async () => {
@@ -59,10 +59,10 @@ describe('SSteps', () => {
         });
 
         // Assert
-        screen.getByRole('navigation', { name: 'Progress' });
-        screen.getByRole('link', { name: 'First step' });
-        screen.getByRole('link', { name: 'Second steptest description' });
-        screen.getByRole('link', { name: '' });
+        expect(screen.getByRole('navigation', { name: 'Progress' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'First step' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Second steptest description' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: '' })).toBeInTheDocument();
     });
 
     test('Can be rendered with simple variant', async () => {
@@ -87,10 +87,10 @@ describe('SSteps', () => {
         });
 
         // Assert
-        screen.getByRole('navigation', { name: 'Progress' });
-        screen.getByRole('link', { name: 'First step' });
-        screen.getByRole('link', { name: 'Second steptest description' });
-        screen.getByRole('link', { name: 'Third step' });
+        expect(screen.getByRole('navigation', { name: 'Progress' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'First step' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Second steptest description' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Third step' })).toBeInTheDocument();
     });
 
     test('Reacts to variant prop changes', async () => {

--- a/src/components/spartan/SSwitch/SSwitch.test.ts
+++ b/src/components/spartan/SSwitch/SSwitch.test.ts
@@ -29,7 +29,7 @@ describe('SSwitch', () => {
         render(SSwitch);
 
         // Assert
-        screen.getByRole('switch');
+        expect(screen.getByRole('switch')).toBeInTheDocument();
     });
 
     test('Can be rendered with label', () => {
@@ -202,7 +202,7 @@ describe('SSwitch', () => {
         });
 
         // Assert
-        screen.getByTestId('icon-off');
-        screen.getByTestId('icon-on');
+        expect(screen.getByTestId('icon-off')).toBeInTheDocument();
+        expect(screen.getByTestId('icon-on')).toBeInTheDocument();
     });
 });

--- a/src/components/spartan/STable/STable.test.ts
+++ b/src/components/spartan/STable/STable.test.ts
@@ -31,11 +31,11 @@ describe('STable', () => {
         render(STable, { slots: { default: [Head, Body] } });
 
         // Assert
-        screen.getByRole('table');
-        screen.getByRole('columnheader', { name: 'Name' });
-        screen.getByRole('columnheader', { name: 'Email' });
-        screen.getByRole('cell', { name: 'John Doe' });
-        screen.getByRole('cell', { name: 'john.doe@email.com' });
+        expect(screen.getByRole('table')).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: 'Email' })).toBeInTheDocument();
+        expect(screen.getByRole('cell', { name: 'John Doe' })).toBeInTheDocument();
+        expect(screen.getByRole('cell', { name: 'john.doe@email.com' })).toBeInTheDocument();
     });
 
     test('Auto-generates table from cols and rows', () => {
@@ -49,11 +49,11 @@ describe('STable', () => {
             },
         });
 
-        screen.getByRole('table');
-        screen.getByRole('columnheader', { name: 'Name' });
-        screen.getByRole('columnheader', { name: 'Email' });
-        screen.getByRole('cell', { name: 'Alice' });
-        screen.getByRole('cell', { name: 'bob@test.com' });
+        expect(screen.getByRole('table')).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: 'Email' })).toBeInTheDocument();
+        expect(screen.getByRole('cell', { name: 'Alice' })).toBeInTheDocument();
+        expect(screen.getByRole('cell', { name: 'bob@test.com' })).toBeInTheDocument();
     });
 
     test('Auto-generates table with highlight', () => {


### PR DESCRIPTION
29 tests across 17 files had no `expect()` call — they relied on `screen.getBy*` throwing when a query fails. That is a real assertion, but an implicit one, which is why Sonar flagged it and why it reads as a weak smoke test.

Wrapped every bare `screen.getBy*(...)` statement in `expect(...).toBeInTheDocument()`. Behaviour is unchanged: getBy still throws first if the element is absent, and the matcher then confirms it is attached. Applied across the whole of each touched file, not only the flagged tests, so the codebase is consistent.

The regex deliberately excludes:
- `getAllBy*` — returns an array, on which `toBeInTheDocument()` is invalid.
- chained calls like `screen.getByTestId('x').focus()` — those return undefined, and an over-broad first pass wrapped them, breaking three SPopover focusout tests. Caught by the suite, reverted, and the pattern tightened to match only query statements that end at the query's own closing paren.

Also fixed a genuinely dead assertion in SAlert: `screen.queryByText('Slot content')` sat on its own doing nothing (queryBy returns null rather than throwing). Its comment said the slot should not render, so it is now `expect(...).not.toBeInTheDocument()` — an assertion that would fail if the slot ever leaked.

assertions-in-tests: 29 -> 0. 1032 tests pass.